### PR TITLE
Improve PDF build pipeline and styling

### DIFF
--- a/.github/workflows/auto_format.yml
+++ b/.github/workflows/auto_format.yml
@@ -1,0 +1,33 @@
+name: Auto Format Markdown
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: markdown linter
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v0.17.2
+        with:
+          fix: true
+          config: 'config/.markdownlint.json'
+          globs: |
+            README.md
+
+      - name: commit markdownlint fixes
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
+        with:
+          commit_message: "chore: apply markdownlint fixes [skip ci]"
+          commit_user_name: GitHub Actions
+          commit_user_email: actions@github.com
+          file_pattern: README.md

--- a/.github/workflows/build_and_update.yml
+++ b/.github/workflows/build_and_update.yml
@@ -25,11 +25,11 @@ jobs:
           globs: |
             README.md
 
-      - name: install pandoc
-        run: sudo apt-get install -y pandoc texlive-luatex texlive-lang-japanese texlive-latex-extra texlive-fonts-recommended 
-          
+      - name: install pdf toolchain
+        run: bash scripts/install-pdf-deps.sh
+
       - name: convert markdown to pdf
-        run: pandoc README.md -o resume.pdf --pdf-engine=lualatex -V documentclass=ltjsarticle -V luatexjapresetoptions=morisawa -V indent=true
+        run: pandoc README.md --defaults=config/pandoc/pdf.yml
 
       - name: resume zip archive
         run: zip resume.zip resume.pdf

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -24,11 +24,11 @@ jobs:
           globs: |
             README.md
 
-      - name: install pandoc
-        run: sudo apt-get install -y pandoc texlive-luatex texlive-lang-japanese texlive-latex-extra texlive-fonts-recommended 
-                  
+      - name: install pdf toolchain
+        run: bash scripts/install-pdf-deps.sh
+
       - name: convert markdown to pdf
-        run: pandoc README.md -o resume.pdf --pdf-engine=lualatex -V documentclass=ltjsarticle -V luatexjapresetoptions=morisawa -V indent=true
+        run: pandoc README.md --defaults=config/pandoc/pdf.yml
 
       - name: upload artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/manual_workflow.yml
+++ b/.github/workflows/manual_workflow.yml
@@ -18,11 +18,11 @@ jobs:
           globs: |
             README.md
 
-      - name: install pandoc
-        run: sudo apt-get install -y pandoc texlive-luatex texlive-lang-japanese texlive-latex-extra texlive-fonts-recommended 
-                  
+      - name: install pdf toolchain
+        run: bash scripts/install-pdf-deps.sh
+
       - name: convert markdown to pdf
-        run: pandoc README.md -o resume.pdf --pdf-engine=lualatex -V documentclass=ltjsarticle -V luatexjapresetoptions=morisawa -V indent=true
+        run: pandoc README.md --defaults=config/pandoc/pdf.yml
 
       - name: upload artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM ubuntu:24.04 
+FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
     pandoc \
     texlive-luatex \
     texlive-lang-japanese \
     texlive-latex-extra \
-    texlive-fonts-recommended 
+    texlive-fonts-recommended \
+    fonts-inconsolata \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
 
 COPY README.md README.md
+COPY config/pandoc/ config/pandoc/
 
-RUN pandoc README.md \
-    -o resume.pdf \
-    --pdf-engine=lualatex \
-    -V documentclass=ltjsarticle \
-    -V luatexjapresetoptions=morisawa \
-    -V indent=true
-
+RUN pandoc README.md --defaults=config/pandoc/pdf.yml

--- a/config/pandoc/pdf.yml
+++ b/config/pandoc/pdf.yml
@@ -1,0 +1,20 @@
+from: markdown+footnotes+autolink_bare_uris
+to: pdf
+standalone: true
+pdf-engine: lualatex
+output-file: resume.pdf
+variables:
+  documentclass: ltjsarticle
+  luatexjapresetoptions: haranoaji
+  indent: true
+  fontsize: 11pt
+  geometry: top=18mm,bottom=18mm,left=18mm,right=18mm
+  mainfont: HaranoAjiMincho
+  sansfont: HaranoAjiGothic
+  monofont: Inconsolata
+  colorlinks: true
+  linkcolor: MidnightBlue
+number-sections: false
+highlight-style: pygments
+include-in-header:
+  - config/pandoc/preamble.tex

--- a/config/pandoc/preamble.tex
+++ b/config/pandoc/preamble.tex
@@ -1,0 +1,18 @@
+% Pandoc preamble additions to make the generated resume easier to read.
+\usepackage{microtype}
+\usepackage{xcolor}
+\usepackage{hyperref}
+\definecolor{linkcolor}{HTML}{1F66AD}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=linkcolor,
+  urlcolor=linkcolor,
+  citecolor=linkcolor
+}
+\usepackage{setspace}
+\setstretch{1.15}
+\usepackage{enumitem}
+\setlist[itemize]{leftmargin=1.5em,labelsep=0.5em}
+\setlist{nosep}
+\setlength{\parskip}{0.45em}
+\setlength{\parindent}{0pt}

--- a/scripts/install-pdf-deps.sh
+++ b/scripts/install-pdf-deps.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v sudo >/dev/null 2>&1; then
+  echo "sudo is required to install system packages" >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  pandoc \
+  texlive-luatex \
+  texlive-lang-japanese \
+  texlive-latex-extra \
+  texlive-fonts-recommended \
+  fonts-inconsolata
+
+sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add a push-triggered workflow that runs markdownlint with auto-fix on README edits
- auto-commit formatting fixes back to the source branch with a skip-ci message to avoid recursive runs
- keep action versions pinned and restrict execution to non-main pushes

## Testing
- docker build --progress plain -t resume-builder . (previous run)